### PR TITLE
Fix to TTS cleanup

### DIFF
--- a/core/tts_utils.py
+++ b/core/tts_utils.py
@@ -43,3 +43,4 @@ def speak(text: str, voice_id: str, *, playback_cmd: str = "afplay") -> None:
     with open(fname, "wb") as f:
         f.write(r.content)
     os.system(f"{playback_cmd} {fname}")
+    os.remove(fname)


### PR DESCRIPTION
## Summary
- ensure temporary ElevenLabs audio files are deleted after playback

## Testing
- `python -m py_compile core/tts_utils.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68557301c67c832089fb04189b9643de