### PR TITLE
Add new agent seeds and memory mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,42 +1,93 @@
 """Terminal chat launcher for AugTwins."""
+from typing import Dict
+
 # Agents
-from seeds.alex import alex
-from seeds.nina import nina
+from seeds.yuvraj import yuvraj, SEED_MEMORIES as YUVRAJ_MEM
+from seeds.dunya import dunya, SEED_MEMORIES as DUNYA_MEM
+from seeds.lars import lars, SEED_MEMORIES as LARS_MEM
+from seeds.anushhka import anushhka, SEED_MEMORIES as ANUSHHKA_MEM
+from seeds.mateo import mateo, SEED_MEMORIES as MATEO_MEM
+from seeds.alif import alif, SEED_MEMORIES as ALIF_MEM
 
 from core.memory_utils import load_memories, save_memories, summarize_recent
 
-# Reload persisted memories
-alex.memory = load_memories("alex") or alex.memory
-nina.memory = load_memories("nina") or nina.memory
+SEEDS: Dict[str, Dict[str, list[str]]] = {
+    "yuvraj": YUVRAJ_MEM,
+    "dünya": DUNYA_MEM,
+    "lars": LARS_MEM,
+    "anushhka": ANUSHHKA_MEM,
+    "mateo": MATEO_MEM,
+    "alif": ALIF_MEM,
+}
+
+AGENTS = {
+    "yuvraj": yuvraj,
+    "dünya": dunya,
+    "lars": lars,
+    "anushhka": anushhka,
+    "mateo": mateo,
+    "alif": alif,
+}
+
+
+def load_for_mode(agent, mode: str) -> None:
+    mems = load_memories(agent.name, mode=mode)
+    if mems:
+        agent.memory = mems
+    else:
+        for txt in SEEDS[agent.name.lower()].get(mode, []):
+            agent.add_memory(txt)
+
 
 def main() -> None:
-    current = alex
-    print("\n=== Digital Twin Chat ===\nCommands: switch  summary  save  exit\n")
+    current = AGENTS["yuvraj"]
+    mode = "combined"
+    load_for_mode(current, mode)
+    print(
+        "\n=== Digital Twin Chat ===\n"
+        "Commands: agent <name>  mode <interview|web|combined>  summary  save  exit\n"
+    )
     try:
         while True:
-            msg = input(f"You → {current.name}: ").strip()
+            msg = input(f"You → {current.name} ({mode}): ").strip()
+            if not msg:
+                continue
             cmd = msg.lower()
             if cmd == "exit":
                 break
-            if cmd == "switch":
-                save_memories(current)
-                current = nina if current is alex else alex
-                print(f"[Switched to {current.name}]\n")
+            if cmd.startswith("agent "):
+                new = cmd.split(maxsplit=1)[1]
+                if new in AGENTS:
+                    save_memories(current, mode=mode)
+                    current = AGENTS[new]
+                    load_for_mode(current, mode)
+                    print(f"[Switched to {current.name}]\n")
+                else:
+                    print("[Unknown agent]\n")
+                continue
+            if cmd.startswith("mode "):
+                new_mode = cmd.split(maxsplit=1)[1]
+                if new_mode in {"interview", "web", "combined"}:
+                    save_memories(current, mode=mode)
+                    mode = new_mode
+                    load_for_mode(current, mode)
+                    print(f"[Memory mode: {mode}]\n")
+                else:
+                    print("[Invalid mode]\n")
                 continue
             if cmd == "save":
-                save_memories(current)
+                save_memories(current, mode=mode)
                 print("[Memories saved]\n")
                 continue
             if cmd == "summary":
                 print(f"\n{current.name} summary:\n{summarize_recent(current)}\n")
                 continue
 
-            # normal conversation
             reply = current.generate_response(msg)
             print(f"{current.name}: {reply}\n")
             current.speak(reply)
     finally:
-        save_memories(current)
+        save_memories(current, mode=mode)
         print("Goodbye – memories stored.\n")
 
 if __name__ == "__main__":

--- a/core/memory_utils.py
+++ b/core/memory_utils.py
@@ -39,33 +39,32 @@ def _use_remote() -> bool:
     return bool(_MEM0_KEY and requests)
 
 
-def _path(name: str) -> Path:
-    return _DIR / f"{name.lower()}_memories.json"
+def _path(name: str, mode: str = "combined") -> Path:
+    return _DIR / f"{name.lower()}_{mode}_memories.json"
 
 
-def _remote_url(name: str) -> str:
-    return f"{_BASE_URL}/agents/{name.lower()}/memories"
+def _remote_url(name: str, mode: str) -> str:
+    return f"{_BASE_URL}/agents/{name.lower()}/memories/{mode}"
 
 
 # save / load
-def save_memories(agent: "Agent") -> None:          # quotes avoid runtime eval
+def save_memories(agent: "Agent", mode: str = "combined") -> None:  # quotes avoid runtime eval
     data = [m.__dict__ for m in agent.memory]
     if _use_remote():
         headers = {"Authorization": f"Bearer {_MEM0_KEY}", "Content-Type": "application/json"}
         try:
-            r = requests.post(_remote_url(agent.name), json=data, headers=headers, timeout=30)
+            r = requests.post(_remote_url(agent.name, mode), json=data, headers=headers, timeout=30)
             r.raise_for_status()
         except Exception as e:
             print("[Mem0 save error]", e)
-            # Fallback to local persistence if remote fails
-            with _path(agent.name).open("w", encoding="utf-8") as f:
+            with _path(agent.name, mode).open("w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
     else:
-        with _path(agent.name).open("w", encoding="utf-8") as f:
+        with _path(agent.name, mode).open("w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
 
 
-def load_memories(name: str) -> List["Memory"]:
+def load_memories(name: str, mode: str = "combined") -> List["Memory"]:
     """
     Lazy-import Memory *inside* the function to avoid circular imports.
     Called only after core.agent has finished initialising.
@@ -75,13 +74,13 @@ def load_memories(name: str) -> List["Memory"]:
     if _use_remote():
         headers = {"Authorization": f"Bearer {_MEM0_KEY}"}
         try:
-            r = requests.get(_remote_url(name), headers=headers, timeout=30)
+            r = requests.get(_remote_url(name, mode), headers=headers, timeout=30)
             r.raise_for_status()
             data = r.json()
         except Exception as e:
             print("[Mem0 load error]", e)
     if not data:
-        p = _path(name)
+        p = _path(name, mode)
         if p.exists():
             with p.open("r", encoding="utf-8") as f:
                 data = json.load(f)

--- a/documentation_agent.py
+++ b/documentation_agent.py
@@ -24,8 +24,12 @@ SOURCE_FILES = [
     "core/llm_utils.py",
     "core/agent.py",
     "core/memory_utils.py",
-    "seeds/alex.py",
-    "seeds/nina.py",
+    "seeds/yuvraj.py",
+    "seeds/dunya.py",
+    "seeds/lars.py",
+    "seeds/anushhka.py",
+    "seeds/mateo.py",
+    "seeds/alif.py",
 ]
 
 

--- a/seeds/alif.py
+++ b/seeds/alif.py
@@ -1,0 +1,19 @@
+from core.agent import Agent
+
+SEED_MEMORIES = {
+    "interview": [
+        "I'm from New York and work in software development."
+    ],
+    "web": [
+        "I'm very interested in multiplayer platforms for coding."
+    ]
+}
+SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+
+alif = Agent(
+    name="Alif",
+    personality="Software developer from New York fascinated by multiplayer coding platforms.",
+    tts_voice_id="",
+)
+for txt in SEED_MEMORIES["combined"]:
+    alif.add_memory(txt)

--- a/seeds/anushhka.py
+++ b/seeds/anushhka.py
@@ -1,0 +1,20 @@
+from core.agent import Agent
+
+SEED_MEMORIES = {
+    "interview": [
+        "I'm from India and study at SCAD.",
+        "My boyfriend is Lars and we share a dragon pet named Sara."
+    ],
+    "web": [
+        "I practice Transcendental Meditation and love Radiohead and Led Zeppelin."
+    ]
+}
+SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+
+anushhka = Agent(
+    name="Anushhka",
+    personality="Creative soul from India who practices Transcendental Meditation.",
+    tts_voice_id="",
+)
+for txt in SEED_MEMORIES["combined"]:
+    anushhka.add_memory(txt)

--- a/seeds/dunya.py
+++ b/seeds/dunya.py
@@ -1,0 +1,20 @@
+from core.agent import Agent
+
+SEED_MEMORIES = {
+    "interview": [
+        "I'm from Germany and study at the Fluid Interfaces group at MIT Media Lab.",
+        "I organize the Augmentation Lab."
+    ],
+    "web": [
+        "Online posts describe my interest in digital twins and human augmentation."
+    ]
+}
+SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+
+dunya = Agent(
+    name="Dünya",
+    personality="Researcher focused on digital twins and human augmentation.",
+    tts_voice_id="",
+)
+for txt in SEED_MEMORIES["combined"]:
+    dunya.add_memory(txt)

--- a/seeds/lars.py
+++ b/seeds/lars.py
@@ -1,0 +1,20 @@
+from core.agent import Agent
+
+SEED_MEMORIES = {
+    "interview": [
+        "I'm from Germany and Virginia and study immersive experiences at SCAD.",
+        "My girlfriend is Anushhka and we have a dragon pet named Sara."
+    ],
+    "web": [
+        "I love music from the '60s and '70s."
+    ]
+}
+SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+
+lars = Agent(
+    name="Lars",
+    personality="Immersive experiences student who loves classic music.",
+    tts_voice_id="",
+)
+for txt in SEED_MEMORIES["combined"]:
+    lars.add_memory(txt)

--- a/seeds/mateo.py
+++ b/seeds/mateo.py
@@ -1,0 +1,20 @@
+from core.agent import Agent
+
+SEED_MEMORIES = {
+    "interview": [
+        "I'm from Quito, Ecuador and study HCI and Computer Music at Stanford.",
+        "My girlfriend is Marielisa and my dog Florencia is a Labradane."
+    ],
+    "web": [
+        "I'm interested in Buddhism and my favorite band is Radiohead."
+    ]
+}
+SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+
+mateo = Agent(
+    name="Mateo",
+    personality="Musician and researcher from Quito fascinated by HCI and Buddhism.",
+    tts_voice_id="",
+)
+for txt in SEED_MEMORIES["combined"]:
+    mateo.add_memory(txt)

--- a/seeds/yuvraj.py
+++ b/seeds/yuvraj.py
@@ -1,0 +1,20 @@
+from core.agent import Agent
+
+SEED_MEMORIES = {
+    "interview": [
+        "I grew up in both the Bay Area and India.",
+        "I studied Computer Science and Statistics at UC Davis."
+    ],
+    "web": [
+        "Articles mention my interest in using large language models for programming."
+    ]
+}
+SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+
+yuvraj = Agent(
+    name="Yuvraj",
+    personality="Curious coder from the Bay Area and India who studied CS and Stats at UC Davis.",
+    tts_voice_id="",
+)
+for txt in SEED_MEMORIES["combined"]:
+    yuvraj.add_memory(txt)


### PR DESCRIPTION
## Summary
- seed six new agents with background memories
- support loading memories by interview/web/combined mode
- let the CLI pick an agent and memory mode
- update documentation assistant source list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685866dbb4bc8320875de6cc0b5b87b4