### PR TITLE
Enhance startup with seed database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 """Terminal chat launcher for AugTwins."""
 from typing import Dict
 
+from core import seed_db
+
 # Agents
 from seeds.yuvraj import yuvraj, SEED_MEMORIES as YUVRAJ_MEM
 from seeds.dunya import dunya, SEED_MEMORIES as DUNYA_MEM
@@ -34,12 +36,17 @@ def load_for_mode(agent, mode: str) -> None:
     mems = load_memories(agent.name, mode=mode)
     if mems:
         agent.memory = mems
+        agent.rebuild_graph()
     else:
-        for txt in SEEDS[agent.name.lower()].get(mode, []):
+        seeds = seed_db.load_seed_memories(agent.name, mode=mode)
+        if not seeds:
+            seeds = SEEDS.get(agent.name.lower(), {}).get(mode, [])
+        for txt in seeds:
             agent.add_memory(txt)
 
 
 def main() -> None:
+    seed_db.init_db()
     current = AGENTS["mateo"]
     mode = "combined"
     load_for_mode(current, mode)

--- a/core/seed_db.py
+++ b/core/seed_db.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import sqlite3
+from pathlib import Path
+from typing import List, Union
+
+DB_PATH = Path("seed_data.db")
+
+
+def init_db(path: Union[str, Path] = DB_PATH) -> None:
+    """Create the seeds table and insert dummy data if none exist."""
+    path = Path(path)
+    with sqlite3.connect(path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """CREATE TABLE IF NOT EXISTS seeds (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                text TEXT NOT NULL
+            )"""
+        )
+        conn.commit()
+        cur.execute("SELECT COUNT(*) FROM seeds")
+        if cur.fetchone()[0] == 0:
+            sample = [
+                ("mateo", "interview", "I study HCI at Stanford."),
+                ("mateo", "web", "I enjoy Radiohead."),
+                ("dünya", "interview", "I was born in Turkey."),
+                ("dünya", "web", "I like to dance."),
+            ]
+            cur.executemany(
+                "INSERT INTO seeds(agent, mode, text) VALUES(?, ?, ?)", sample
+            )
+            conn.commit()
+
+
+def load_seed_memories(
+    agent: str,
+    mode: str = "combined",
+    *,
+    path: Union[str, Path] = DB_PATH,
+) -> List[str]:
+    """Return seed memory texts for *agent* and *mode* from the database."""
+    path = Path(path)
+    if not path.exists():
+        return []
+    agent = agent.lower()
+    with sqlite3.connect(path) as conn:
+        cur = conn.cursor()
+        if mode == "combined":
+            cur.execute("SELECT text FROM seeds WHERE agent=? ORDER BY id", (agent,))
+        else:
+            cur.execute(
+                "SELECT text FROM seeds WHERE agent=? AND mode=? ORDER BY id",
+                (agent, mode),
+            )
+        rows = cur.fetchall()
+    return [r[0] for r in rows]

--- a/tests/test_seed_db.py
+++ b/tests/test_seed_db.py
@@ -1,0 +1,13 @@
+from core import seed_db
+
+
+def test_seed_db(tmp_path):
+    db = tmp_path / "seed.db"
+    seed_db.init_db(db)
+
+    interview = seed_db.load_seed_memories("mateo", "interview", path=db)
+    web = seed_db.load_seed_memories("mateo", "web", path=db)
+    combined = seed_db.load_seed_memories("mateo", "combined", path=db)
+
+    assert set(combined) == set(interview + web)
+    assert interview and web


### PR DESCRIPTION
## Summary
- add `seed_db` module with SQLite-based seed memory storage
- load seed memories from the database when none exist on disk
- initialize the database on startup
- test seed database utilities
- clean up unused imports and use safe context managers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8969865c8320a85c1c4c93bd979d