### PR TITLE
Handle Mem0 404s gracefully

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -185,7 +185,10 @@ class Agent:
                 r.raise_for_status()
                 results = r.json().get("results", [])
             except Exception as e:
-                print("[Mem0 search error]", e)
+                if getattr(e, "response", None) and getattr(e.response, "status_code", None) == 404:
+                    print("[Mem0 search error] remote search not found; using local memories")
+                else:
+                    print("[Mem0 search error]", e)
 
         local_results: List[str] = []
         if self.memory:

--- a/core/memory_utils.py
+++ b/core/memory_utils.py
@@ -56,7 +56,10 @@ def save_memories(agent: "Agent", mode: str = "combined") -> None:  # quotes avo
             r = requests.post(_remote_url(agent.name, mode), json=data, headers=headers, timeout=30)
             r.raise_for_status()
         except Exception as e:
-            print("[Mem0 save error]", e)
+            if getattr(e, "response", None) and getattr(e.response, "status_code", None) == 404:
+                print("[Mem0 save error] remote agent or mode not found; using local file")
+            else:
+                print("[Mem0 save error]", e)
             with _path(agent.name, mode).open("w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
     else:
@@ -78,7 +81,10 @@ def load_memories(name: str, mode: str = "combined") -> List["Memory"]:
             r.raise_for_status()
             data = r.json()
         except Exception as e:
-            print("[Mem0 load error]", e)
+            if getattr(e, "response", None) and getattr(e.response, "status_code", None) == 404:
+                print("[Mem0 load error] remote memories not found; falling back to local")
+            else:
+                print("[Mem0 load error]", e)
     if not data:
         p = _path(name, mode)
         if p.exists():


### PR DESCRIPTION
## Summary
- handle HTTP 404 errors from the Mem0 API when loading/saving memories
- handle HTTP 404 errors during remote search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8f19a2e08320ab1339a3eea6d988