### PR TITLE
Fix duplicate name responses and document Mem0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ pip install -r requirements.txt
 
 Running `app.py` requires the packages in `requirements.txt`.  The tests stub out
 heavy dependencies so they can run without network access.
+
+## Mem0 integration
+
+The app can optionally sync memories to [Mem0](https://mem0.ai).  To enable this
+feature, set the environment variable `MEM0_API_KEY` to a valid API key.  If the
+remote service or agent does not exist, the code falls back to local JSON files
+in the `memories/` directory.  `404` errors during startup are therefore
+harmless and usually mean the remote agent or mode hasn’t been created yet.

--- a/core/agent.py
+++ b/core/agent.py
@@ -219,8 +219,13 @@ class Agent:
             f"User: {user_msg}\n{self.name}:"
         )
         answer = llm_utils.chat([{"role": "system", "content": prompt}], model=model)
-        self.add_memory(f"User: {user_msg}\n{self.name}: {answer}")
-        return answer
+        # The model sometimes echoes the "Name:" prefix; strip it if present
+        cleaned = answer.lstrip()
+        prefix = f"{self.name}:"
+        if cleaned.lower().startswith(prefix.lower()):
+            cleaned = cleaned[len(prefix):].lstrip()
+        self.add_memory(f"User: {user_msg}\n{self.name}: {cleaned}")
+        return cleaned
 
        # Speech synthesis (delegates to tts_utils)
     def speak(self, text: str, playback_cmd: str = "afplay") -> None:


### PR DESCRIPTION
## Summary
- strip agent name from LLM replies to avoid `Mateo: Mateo:` outputs
- explain optional Mem0 integration and 404 errors in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b917316988320921ae099ecdff1f5