### PR TITLE
Add utterance module with transcript style

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ pip install -r requirements.txt
 Running `app.py` requires the packages in `requirements.txt`.  The tests stub out
 heavy dependencies so they can run without network access.
 
+## Transcripts and utterances
+
+Each agent can mimic a specific speaking style.  The `transcripts/` directory
+contains short example snippets used by `core.utterance_utils` to guide the LLM.
+`Agent.generate_response` now calls this helper with a slightly higher
+temperature (0.5) so replies sound more natural and less robotic.
+
 ## Mem0 integration
 
 The app can optionally sync memories to [Mem0](https://mem0.ai).  To enable this

--- a/core/utterance_utils.py
+++ b/core/utterance_utils.py
@@ -1,0 +1,53 @@
+"""Utilities for crafting agent utterances with transcript-based style cues."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from . import llm_utils
+
+_TRANS_DIR = Path("transcripts")
+
+
+def load_transcript(name: str) -> str:
+    """Return text from transcripts/<name>.txt if available."""
+    path = _TRANS_DIR / f"{name.lower()}.txt"
+    if path.exists():
+        return path.read_text(encoding="utf-8").strip()
+    return ""
+
+
+def generate_utterance(
+    *,
+    agent_name: str,
+    personality: str,
+    user_msg: str,
+    relevant: str,
+    graph_info: str,
+    model: str = "gpt-4o-mini",
+    temperature: float = 0.5,
+) -> str:
+    """Generate a reply in the style of *agent_name*, referencing transcripts."""
+    transcript = load_transcript(agent_name)
+    prompt = (
+        f"You are {agent_name}. Personality: {personality}\n"
+        "Speak casually, like a normal person. It's okay to use fragments or short answers. "
+        "Only end with a question if it feels natural.\n"
+    )
+    if transcript:
+        prompt += f"Example speech from transcript:\n{transcript}\n\n"
+    prompt += (
+        f"Relevant memories:\n{relevant}\n"
+        f"Graph context: {graph_info}\n\n"
+        f"User: {user_msg}\n{agent_name}:"
+    )
+    answer = llm_utils.chat(
+        [{"role": "system", "content": prompt}],
+        model=model,
+        temperature=temperature,
+    )
+    cleaned = answer.lstrip()
+    prefix = f"{agent_name}:"
+    if cleaned.lower().startswith(prefix.lower()):
+        cleaned = cleaned[len(prefix):].lstrip()
+    return cleaned

--- a/core/utterance_utils.py
+++ b/core/utterance_utils.py
@@ -1,4 +1,7 @@
-"""Utilities for crafting agent utterances with transcript-based style cues."""
+"""Utilities for crafting agent utterances with transcript-based style cues.
+
+The transcript snippets describe how an agent speaks—not their favorite topics
+or catchphrases. They guide delivery, phrasing, and rhythm only."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/transcripts/alif.txt
+++ b/transcripts/alif.txt
@@ -1,0 +1,1 @@
+Alif uses casual language and sometimes drops the subject from sentences.

--- a/transcripts/anushhka.txt
+++ b/transcripts/anushhka.txt
@@ -1,0 +1,1 @@
+Anushhka likes excited interjections and short, punchy statements.

--- a/transcripts/dunya.txt
+++ b/transcripts/dunya.txt
@@ -1,0 +1,1 @@
+Dunya often pauses and starts sentences with 'Well,' when thinking.

--- a/transcripts/lars.txt
+++ b/transcripts/lars.txt
@@ -1,0 +1,1 @@
+Lars tends to speak in a laid-back manner, using filler words like 'uh' or 'you know.'

--- a/transcripts/mateo.txt
+++ b/transcripts/mateo.txt
@@ -1,0 +1,1 @@
+Mateo tends to speak in short phrases and often mentions his dog Florencia.

--- a/transcripts/mateo.txt
+++ b/transcripts/mateo.txt
@@ -1,1 +1,1 @@
-Mateo tends to speak in short phrases and often mentions his dog Florencia.
+Mateo tends to speak in short phrases and uses casual asides.

--- a/transcripts/yuvraj.txt
+++ b/transcripts/yuvraj.txt
@@ -1,0 +1,1 @@
+Yuvraj is brief and to the point, often skipping small talk.


### PR DESCRIPTION
## Summary
- tweak Agent.generate_response to route through new helper
- craft `core/utterance_utils` to reference transcript text and increase sampling temperature
- add dummy transcripts for existing agents
- document transcript directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c222719288320ade5b91e5ea0d92e