### PR TITLE
Simplify memory management

### DIFF
--- a/core/seed_db.py
+++ b/core/seed_db.py
@@ -15,7 +15,6 @@ def init_db(path: Union[str, Path] = DB_PATH) -> None:
             """CREATE TABLE IF NOT EXISTS seeds (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 agent TEXT NOT NULL,
-                mode TEXT NOT NULL,
                 text TEXT NOT NULL
             )"""
         )
@@ -23,36 +22,29 @@ def init_db(path: Union[str, Path] = DB_PATH) -> None:
         cur.execute("SELECT COUNT(*) FROM seeds")
         if cur.fetchone()[0] == 0:
             sample = [
-                ("mateo", "interview", "I study HCI at Stanford."),
-                ("mateo", "web", "I enjoy Radiohead."),
-                ("dünya", "interview", "I was born in Turkey."),
-                ("dünya", "web", "I like to dance."),
+                ("mateo", "I study HCI at Stanford."),
+                ("mateo", "I enjoy Radiohead."),
+                ("dünya", "I was born in Turkey."),
+                ("dünya", "I like to dance."),
             ]
             cur.executemany(
-                "INSERT INTO seeds(agent, mode, text) VALUES(?, ?, ?)", sample
+                "INSERT INTO seeds(agent, text) VALUES(?, ?)", sample
             )
             conn.commit()
 
 
 def load_seed_memories(
     agent: str,
-    mode: str = "combined",
     *,
     path: Union[str, Path] = DB_PATH,
 ) -> List[str]:
-    """Return seed memory texts for *agent* and *mode* from the database."""
+    """Return seed memory texts for *agent* from the database."""
     path = Path(path)
     if not path.exists():
         return []
     agent = agent.lower()
     with sqlite3.connect(path) as conn:
         cur = conn.cursor()
-        if mode == "combined":
-            cur.execute("SELECT text FROM seeds WHERE agent=? ORDER BY id", (agent,))
-        else:
-            cur.execute(
-                "SELECT text FROM seeds WHERE agent=? AND mode=? ORDER BY id",
-                (agent, mode),
-            )
+        cur.execute("SELECT text FROM seeds WHERE agent=? ORDER BY id", (agent,))
         rows = cur.fetchall()
     return [r[0] for r in rows]

--- a/seeds/alif.py
+++ b/seeds/alif.py
@@ -1,19 +1,23 @@
-from core.agent import Agent
+from pathlib import Path
 
-SEED_MEMORIES = {
-    "interview": [
-        "I'm from New York and work in software development."
-    ],
-    "web": [
-        "I'm very interested in multiplayer platforms for coding."
-    ]
-}
-SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+from .profile_base import ProfileAgent
 
-alif = Agent(
-    name="Alif",
-    personality="Software developer from New York fascinated by multiplayer coding platforms.",
-    tts_voice_id="1t1EeRixsJrKbiF1zwM6",
-)
-for txt in SEED_MEMORIES["combined"]:
-    alif.add_memory(txt)
+SEED_MEMORIES = [
+    "I'm from New York and work in software development.",
+    "I'm very interested in multiplayer platforms for coding.",
+]
+
+PERSONA_DESCRIPTION = "Software developer from New York fascinated by multiplayer coding platforms."
+
+
+class Alif(ProfileAgent):
+    transcript_path = Path(__file__).resolve().parents[1] / "transcripts/alif.txt"
+    persona = PERSONA_DESCRIPTION
+
+    def __init__(self) -> None:
+        super().__init__(name="Alif", personality=PERSONA_DESCRIPTION, tts_voice_id="1t1EeRixsJrKbiF1zwM6")
+        for txt in SEED_MEMORIES:
+            self.add_memory(txt)
+
+
+alif = Alif()

--- a/seeds/anushhka.py
+++ b/seeds/anushhka.py
@@ -1,20 +1,24 @@
-from core.agent import Agent
+from pathlib import Path
 
-SEED_MEMORIES = {
-    "interview": [
-        "I'm from India and study at SCAD.",
-        "My boyfriend is Lars and we share a dragon pet named Sara."
-    ],
-    "web": [
-        "I practice Transcendental Meditation and love Radiohead and Led Zeppelin."
-    ]
-}
-SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+from .profile_base import ProfileAgent
 
-anushhka = Agent(
-    name="Anushhka",
-    personality="Creative soul from India who practices Transcendental Meditation.",
-    tts_voice_id="1t1EeRixsJrKbiF1zwM6",
-)
-for txt in SEED_MEMORIES["combined"]:
-    anushhka.add_memory(txt)
+SEED_MEMORIES = [
+    "I'm from India and study at SCAD.",
+    "My boyfriend is Lars and we share a dragon pet named Sara.",
+    "I practice Transcendental Meditation and love Radiohead and Led Zeppelin.",
+]
+
+PERSONA_DESCRIPTION = "Creative soul from India who practices Transcendental Meditation."
+
+
+class Anushhka(ProfileAgent):
+    transcript_path = Path(__file__).resolve().parents[1] / "transcripts/anushhka.txt"
+    persona = PERSONA_DESCRIPTION
+
+    def __init__(self) -> None:
+        super().__init__(name="Anushhka", personality=PERSONA_DESCRIPTION, tts_voice_id="1t1EeRixsJrKbiF1zwM6")
+        for txt in SEED_MEMORIES:
+            self.add_memory(txt)
+
+
+anushhka = Anushhka()

--- a/seeds/dunya.py
+++ b/seeds/dunya.py
@@ -1,20 +1,24 @@
-from core.agent import Agent
+from pathlib import Path
 
-SEED_MEMORIES = {
-    "interview": [
-        "I'm from Germany and study at the Fluid Interfaces group at MIT Media Lab.",
-        "I organize the Augmentation Lab."
-    ],
-    "web": [
-        "Online posts describe my interest in digital twins and human augmentation."
-    ]
-}
-SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+from .profile_base import ProfileAgent
 
-dunya = Agent(
-    name="Dünya",
-    personality="Researcher focused on digital twins and human augmentation.",
-    tts_voice_id="1t1EeRixsJrKbiF1zwM6",
-)
-for txt in SEED_MEMORIES["combined"]:
-    dunya.add_memory(txt)
+SEED_MEMORIES = [
+    "I'm from Germany and study at the Fluid Interfaces group at MIT Media Lab.",
+    "I organize the Augmentation Lab.",
+    "Online posts describe my interest in digital twins and human augmentation.",
+]
+
+PERSONA_DESCRIPTION = "Researcher focused on digital twins and human augmentation."
+
+
+class Dunya(ProfileAgent):
+    transcript_path = Path(__file__).resolve().parents[1] / "transcripts/dunya.txt"
+    persona = PERSONA_DESCRIPTION
+
+    def __init__(self) -> None:
+        super().__init__(name="Dünya", personality=PERSONA_DESCRIPTION, tts_voice_id="1t1EeRixsJrKbiF1zwM6")
+        for txt in SEED_MEMORIES:
+            self.add_memory(txt)
+
+
+dunya = Dunya()

--- a/seeds/lars.py
+++ b/seeds/lars.py
@@ -1,20 +1,24 @@
-from core.agent import Agent
+from pathlib import Path
 
-SEED_MEMORIES = {
-    "interview": [
-        "I'm from Germany and Virginia and study immersive experiences at SCAD.",
-        "My girlfriend is Anushhka and we have a dragon pet named Sara."
-    ],
-    "web": [
-        "I love music from the '60s and '70s."
-    ]
-}
-SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+from .profile_base import ProfileAgent
 
-lars = Agent(
-    name="Lars",
-    personality="Immersive experiences student who loves classic music.",
-    tts_voice_id="5epn2vbuws8S5MRzxJH8",
-)
-for txt in SEED_MEMORIES["combined"]:
-    lars.add_memory(txt)
+SEED_MEMORIES = [
+    "I'm from Germany and Virginia and study immersive experiences at SCAD.",
+    "My girlfriend is Anushhka and we have a dragon pet named Sara.",
+    "I love music from the '60s and '70s.",
+]
+
+PERSONA_DESCRIPTION = "Immersive experiences student who loves classic music."
+
+
+class Lars(ProfileAgent):
+    transcript_path = Path(__file__).resolve().parents[1] / "transcripts/lars.txt"
+    persona = PERSONA_DESCRIPTION
+
+    def __init__(self) -> None:
+        super().__init__(name="Lars", personality=PERSONA_DESCRIPTION, tts_voice_id="5epn2vbuws8S5MRzxJH8")
+        for txt in SEED_MEMORIES:
+            self.add_memory(txt)
+
+
+lars = Lars()

--- a/seeds/mateo.py
+++ b/seeds/mateo.py
@@ -1,20 +1,24 @@
-from core.agent import Agent
+from pathlib import Path
 
-SEED_MEMORIES = {
-    "interview": [
-        "I'm from Quito, Ecuador and study HCI and Computer Music at Stanford.",
-        "My girlfriend is Marielisa and my dog Florencia is a Labradane."
-    ],
-    "web": [
-        "I'm interested in Buddhism and my favorite band is Radiohead."
-    ]
-}
-SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+from .profile_base import ProfileAgent
 
-mateo = Agent(
-    name="Mateo",
-    personality="Musician and researcher from Quito fascinated by HCI and Buddhism.",
-    tts_voice_id="1t1EeRixsJrKbiF1zwM6",
-)
-for txt in SEED_MEMORIES["combined"]:
-    mateo.add_memory(txt)
+SEED_MEMORIES = [
+    "I'm from Quito, Ecuador and study HCI and Computer Music at Stanford.",
+    "My girlfriend is Marielisa and my dog Florencia is a Labradane.",
+    "I'm interested in Buddhism and my favorite band is Radiohead.",
+]
+
+PERSONA_DESCRIPTION = "Musician and researcher from Quito fascinated by HCI and Buddhism."
+
+
+class Mateo(ProfileAgent):
+    transcript_path = Path(__file__).resolve().parents[1] / "transcripts/mateo.txt"
+    persona = PERSONA_DESCRIPTION
+
+    def __init__(self) -> None:
+        super().__init__(name="Mateo", personality=PERSONA_DESCRIPTION, tts_voice_id="1t1EeRixsJrKbiF1zwM6")
+        for txt in SEED_MEMORIES:
+            self.add_memory(txt)
+
+
+mateo = Mateo()

--- a/seeds/profile_base.py
+++ b/seeds/profile_base.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.agent import Agent
+from generate_profile import (
+    build_openai_client,
+    extract_memories,
+    DEFAULT_MODEL,
+    DEFAULT_CHUNK_TOKENS,
+)
+
+
+class ProfileAgent(Agent):
+    """Agent with convenience helpers for transcripts and persona."""
+
+    transcript_path: Path
+    persona: str
+
+    def generate_memories(
+        self,
+        model: str = DEFAULT_MODEL,
+        chunk_tokens: int = DEFAULT_CHUNK_TOKENS,
+    ) -> None:
+        """Use OpenAI to extract memories from the transcript."""
+        if not self.transcript_path.exists():
+            raise FileNotFoundError(self.transcript_path)
+        transcript = self.transcript_path.read_text(encoding="utf-8")
+        client = build_openai_client()
+        memories = extract_memories(client, model, transcript, chunk_tokens)
+        for m in memories:
+            text = m.get("memory") if isinstance(m, dict) else None
+            if text:
+                self.add_memory(text)

--- a/seeds/yuvraj.py
+++ b/seeds/yuvraj.py
@@ -1,20 +1,24 @@
-from core.agent import Agent
+from pathlib import Path
 
-SEED_MEMORIES = {
-    "interview": [
-        "I grew up in both the Bay Area and India.",
-        "I studied Computer Science and Statistics at UC Davis."
-    ],
-    "web": [
-        "Articles mention my interest in using large language models for programming."
-    ]
-}
-SEED_MEMORIES["combined"] = SEED_MEMORIES["interview"] + SEED_MEMORIES["web"]
+from .profile_base import ProfileAgent
 
-yuvraj = Agent(
-    name="Yuvraj",
-    personality="Curious coder from the Bay Area and India who studied CS and Stats at UC Davis.",
-    tts_voice_id="1t1EeRixsJrKbiF1zwM6",
-)
-for txt in SEED_MEMORIES["combined"]:
-    yuvraj.add_memory(txt)
+SEED_MEMORIES = [
+    "I grew up in both the Bay Area and India.",
+    "I studied Computer Science and Statistics at UC Davis.",
+    "Articles mention my interest in using large language models for programming.",
+]
+
+PERSONA_DESCRIPTION = "Curious coder from the Bay Area and India who studied CS and Stats at UC Davis."
+
+
+class Yuvraj(ProfileAgent):
+    transcript_path = Path(__file__).resolve().parents[1] / "transcripts/yuvraj.txt"
+    persona = PERSONA_DESCRIPTION
+
+    def __init__(self) -> None:
+        super().__init__(name="Yuvraj", personality=PERSONA_DESCRIPTION, tts_voice_id="1t1EeRixsJrKbiF1zwM6")
+        for txt in SEED_MEMORIES:
+            self.add_memory(txt)
+
+
+yuvraj = Yuvraj()

--- a/tests/test_mem0_remote.py
+++ b/tests/test_mem0_remote.py
@@ -61,9 +61,9 @@ def test_remote_save_and_load(tmp_path, monkeypatch):
 
     mu.save_memories(agent)
     assert calls["post"]
-    assert calls["post"][0]["url"] == mu._remote_url(agent.name, "combined")
+    assert calls["post"][0]["url"] == mu._remote_url(agent.name)
 
     loaded = mu.load_memories(agent.name)
     assert calls["get"]
-    assert calls["get"][0]["url"] == mu._remote_url(agent.name, "combined")
+    assert calls["get"][0]["url"] == mu._remote_url(agent.name)
     assert loaded and loaded[0].text == "hello"

--- a/tests/test_seed_db.py
+++ b/tests/test_seed_db.py
@@ -5,9 +5,6 @@ def test_seed_db(tmp_path):
     db = tmp_path / "seed.db"
     seed_db.init_db(db)
 
-    interview = seed_db.load_seed_memories("mateo", "interview", path=db)
-    web = seed_db.load_seed_memories("mateo", "web", path=db)
-    combined = seed_db.load_seed_memories("mateo", "combined", path=db)
+    memories = seed_db.load_seed_memories("mateo", path=db)
 
-    assert set(combined) == set(interview + web)
-    assert interview and web
+    assert memories


### PR DESCRIPTION
## Summary
- drop interview/web memory modes
- add `ProfileAgent` with transcript-based memory generation
- convert seed profiles to use new class
- remove mode logic from `app.py`
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862da74dca48320be970d026c336007