### PR TITLE
Improve profile workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ pip install -r requirements.txt
 Running `app.py` requires the packages in `requirements.txt`.  The tests stub out
 heavy dependencies so they can run without network access.
 
+## Interviews and profiles
+
+Raw interview transcripts should live under `interviews/<person>/transcripts/`.
+You can generate these text files from audio using `interviews/transcribe.py`.
+
+Once you have the `.txt` transcripts, run `python generate_profile.py <person>`
+from the project root. This will create three artefacts:
+
+1. `interviews/<person>/memories.json` – structured memories extracted from the
+   transcripts.
+2. `interviews/<person>/persona.json` – a persona description and inferred
+   personality type.
+3. `transcripts/<person>.json` – an utterance style guide referenced by the
+   agent profile (see `seeds/lars.py`). The `transcripts/` directory is created
+   automatically if it does not exist.
+

--- a/generate_profile.py
+++ b/generate_profile.py
@@ -218,7 +218,11 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover
     project_root = Path(__file__).resolve().parent.parent  # hop out of interviews/
     transcripts_dir = project_root / "interviews" / args.person / "transcripts"
     if not transcripts_dir.exists():
-        logging.critical("Transcripts directory not found: %s", transcripts_dir)
+        logging.critical(
+            "Transcripts directory not found: %s. Run transcribe.py first or "
+            "place your .txt files there.",
+            transcripts_dir,
+        )
         sys.exit(1)
 
     txt_files = sorted(transcripts_dir.glob("*.txt"))
@@ -275,6 +279,7 @@ def main(argv: List[str] | None = None) -> None:  # pragma: no cover
     logging.info("Persona written → %s", persona_path)
 
     utter_path = project_root / "transcripts" / f"{args.person.lower()}.json"
+    utter_path.parent.mkdir(parents=True, exist_ok=True)
     utter_path.write_text(json.dumps(utterance, indent=2, ensure_ascii=False))
     logging.info("Utterance guide written → %s", utter_path)
 


### PR DESCRIPTION
## Summary
- document where raw transcripts should live and how profiles are generated
- make generate_profile.py fail with clearer message when transcripts are missing
- ensure the transcripts/ folder for utterance guides is created automatically

## Testing
- `python3 -m py_compile generate_profile.py seeds/profile_base.py seeds/lars.py core/utterance_utils.py documentation_agent.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fe4eddca883209068bde6bf262d65